### PR TITLE
Update GitHub Actions cron schedule

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,7 @@ name: Docker
 
 on:
   schedule:
-    - cron: '41 1 * * *'
+    - cron: '41 1 * * 0'
   push:
     branches: [ "main" ]
     # Publish semver tags as releases.


### PR DESCRIPTION
Updated the cron schedule in `.github/workflows/docker-publish.yml` from `41 1 * * *` (daily) to `41 1 * * 0` (weekly, on Sunday).

---
*PR created automatically by Jules for task [6934859364113726468](https://jules.google.com/task/6934859364113726468) started by @Walkmana-25*